### PR TITLE
Use name filter to avoid too long paged results

### DIFF
--- a/main.js
+++ b/main.js
@@ -10,7 +10,7 @@ const getCurrentRecordId = () => {
   const { status, stdout } = cp.spawnSync("curl", [
     ...["--header", `Authorization: Bearer ${process.env.INPUT_TOKEN}`],
     ...["--header", "Content-Type: application/json"],
-    `https://api.cloudflare.com/client/v4/zones/${process.env.INPUT_ZONE}/dns_records`,
+    `https://api.cloudflare.com/client/v4/zones/${process.env.INPUT_ZONE}/dns_records?name=${process.env.INPUT_NAME}`,
   ]);
 
   if (status !== 0) {


### PR DESCRIPTION
Heyo :wave: 

I have stumbled upon a bug when this action does nothing if you have many subdomains and you happen to ask for a record that isn't included on the first page of the received API response.

## Example

Let's imagine you have 1220 subdomains and you want to edit subdomain 999. 
Your results will get paged:

```
# getCurrentRecordId
[
  { result 1},
  { result 2} 
  .... 
  { result 20}
],
"success":true,
"errors":[],
"messages":[],
"result_info":{
  "page":1,
  "per_page":20,
  "count":20,
  "total_count":1220,
  "total_pages":60}
}
```

Results 21-1220 are missing, code will not match 999 in results, and so action will exit with a message:

> Record doesn't exist. Nothing to delete.

## Solution

There is a `per_page` argument but it can be set to max 100 anyway so it wouldn't solve this issue. But we can filter by `name?=` and so in most cases it'll get 1 page with that 1 record matched by name.

Let me know if that's sensible, maybe I'm missing something why this action isn't using `?name=` filter in the first place :thinking: 

Cheers! :vulcan_salute: 

PS
I'm not so sure about my JS skills so maybe we need to urlencode that argument somehow? It works for me just fine with my domain containing dots and dashes though :shrug: 